### PR TITLE
pass the root name to TreeBuilder's constructor

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -8,8 +8,14 @@ class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('corley_maintenance');
+        $treeBuilder = new TreeBuilder('corley_maintenance');
+
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $treeBuilder->root('corley_maintenance');
+        }
 
         $rootNode
             ->children()


### PR DESCRIPTION
Since calling the root() method of TreeBuilder is deprecated since Symfony 4.3, pass the root name to the constructor instead.